### PR TITLE
Fix link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,3 +56,4 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
 add_subdirectory(src)
 
+install(FILES package.xml DESTINATION share/apriltags-cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,10 @@ cmake_minimum_required(VERSION 2.6)
 
 project(APRILTAGS)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
-set(CMAKE_CXX_FLAGS "-frounding-math")
 
 if(APPLE)
   include_directories(/opt/local/include) # MacPorts
@@ -57,4 +58,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
 add_subdirectory(src)
 
-install(FILES package.xml DESTINATION share/apriltags-cpp)
+install(DIRECTORY src/ DESTINATION include/apriltags_cpp FILES_MATCHING PATTERN "*.h" PATTERN ".svn" EXCLUDE)
+install(FILES package.xml DESTINATION share/apriltags_cpp)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in "${PROJECT_BINARY_DIR}/apriltags_cppConfig.cmake" @ONLY)
+install(FILES "${PROJECT_BINARY_DIR}/apriltags_cppConfig.cmake" DESTINATION share/apriltags_cpp/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(APRILTAGS)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+set(CMAKE_CXX_FLAGS "-frounding-math")
 
 if(APPLE)
   include_directories(/opt/local/include) # MacPorts

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,3 @@
+set(apriltags_cpp_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../../../include)
+set(apriltags_cpp_LIBRARIES ${CMAKE_CURRENT_LIST_DIR}/../../../lib/@CMAKE_SHARED_LIBRARY_PREFIX@apriltags@CMAKE_SHARED_LIBRARY_SUFFIX@)
+

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>apriltags-cpp</name>
+  <name>apriltags_cpp</name>
   <version>0.0.0</version>
   <description>
     apriltags C++ core library

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>apriltags-cpp</name>
+  <version>0.0.0</version>
+  <description>
+    apriltags C++ core library
+  </description>
+  <url type="repository">https://github.com/personalrobotics/apriltags-cpp</url>
+
+  <maintainer email="awalsman@andrew.cmu.edu">Aaron Walsman</maintainer>
+  <author email="awalsman@andrew.cmu.edu">Aaron Walsman</author>
+  <author email="pkv@cs.cmu.edu">Pras Velagapudi</author>
+
+  <license>BSD</license>
+
+  <exec_depend>catkin</exec_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
 
   <license>BSD</license>
 
+  <depend>cgal</depend>
+
   <exec_depend>catkin</exec_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,8 @@
 
   <depend>cgal</depend>
 
+  <buildtool_depend>cmake</buildtool_depend>
+
   <exec_depend>catkin</exec_depend>
 
   <export>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,28 +11,30 @@ add_library(apriltags SHARED
   UnionFindSimple.cpp
 )
 
-set(AT_LIBS apriltags ${OPENCV_LDFLAGS})
+set(AT_LIBS apriltags)
+
+target_link_libraries(apriltags ${OPENCV_LIBRARIES})
 
 add_executable(camtest camtest.cpp)
-target_link_libraries(camtest ${AT_LIBS})
+target_link_libraries(camtest ${AT_LIBS} ${OPENCV_LIBRARIES})
 
 add_executable(tagtest tagtest.cpp)
-target_link_libraries(tagtest ${AT_LIBS})
+target_link_libraries(tagtest ${AT_LIBS} ${OPENCV_LIBRARIES})
 
 add_executable(quadtest quadtest.cpp)
-target_link_libraries(quadtest ${AT_LIBS})
+target_link_libraries(quadtest ${AT_LIBS} ${OPENCV_LIBRARIES})
 
 if (GLUT_LIBRARY)
 
   add_executable(gltest gltest.cpp)
-  target_link_libraries(gltest ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${AT_LIBS})
+  target_link_libraries(gltest ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${AT_LIBS} ${OPENCV_LIBRARIES})
 
 endif()
 
 if (CAIRO_FOUND)
 
   add_executable(maketags maketags.cpp)
-  target_link_libraries(maketags ${CAIRO_LIBRARIES} ${AT_LIBS} ${CAIRO_LIBS})
+  target_link_libraries(maketags ${CAIRO_LIBRARIES} ${AT_LIBS} ${CAIRO_LIBS} ${OPENCV_LIBRARIES})
 
 endif() 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,8 +13,6 @@ add_library(apriltags SHARED
 
 set(AT_LIBS apriltags ${OPENCV_LDFLAGS})
 
-target_link_libraries(apriltags ${AT_LIBS})
-
 add_executable(camtest camtest.cpp)
 target_link_libraries(camtest ${AT_LIBS})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,5 +37,3 @@ if (CAIRO_FOUND)
 endif() 
 
 install(TARGETS apriltags DESTINATION lib/)
-install(DIRECTORY src/ DESTINATION include/apriltags_cpp FILES_MATCHING PATTERN "*.h" PATTERN ".svn" EXCLUDE)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,5 +37,5 @@ if (CAIRO_FOUND)
 endif() 
 
 install(TARGETS apriltags DESTINATION lib/)
-install(DIRECTORY src/ DESTINATION include/apriltags-cpp FILES_MATCHING PATTERN "*.h" PATTERN ".svn" EXCLUDE)
+install(DIRECTORY src/ DESTINATION include/apriltags_cpp FILES_MATCHING PATTERN "*.h" PATTERN ".svn" EXCLUDE)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(apriltags
+add_library(apriltags SHARED
   CameraUtil.cpp
   DebugImage.cpp
   Geometry.cpp 
@@ -37,3 +37,7 @@ if (CAIRO_FOUND)
   target_link_libraries(maketags ${CAIRO_LIBRARIES} ${AT_LIBS} ${CAIRO_LIBS})
 
 endif() 
+
+install(TARGETS apriltags DESTINATION lib/)
+install(DIRECTORY src/ DESTINATION include/apriltags-cpp FILES_MATCHING PATTERN "*.h" PATTERN ".svn" EXCLUDE)
+


### PR DESCRIPTION
As the CMakeLists.txt file was written, apriltags (the core library) wasn't actually ever linked against OpenCV.
